### PR TITLE
refactor: update start screen

### DIFF
--- a/components/StartScreenFooter.vue
+++ b/components/StartScreenFooter.vue
@@ -1,6 +1,8 @@
 <template>
-  <div class="fixed bottom-0 w-screen mb-2 opacity-50">
-    <div class="flex mx-auto gap-x-4 w-max">
+  <div class="fixed bottom-0 w-screen space-y-2 opacity-50">
+    <div class="flex items-center mx-auto gap-x-4 w-max">
+
+      <!-- PORTFOLIO LINK -->
       <a href="https://www.andrehammons.dev" title="View my portfolio" target="_blank">
         <svg
           version="1.1"
@@ -81,13 +83,15 @@ z"
         </svg>
         <span class="sr-only"> View my portfolio </span>
       </a>
+
+      <!-- GITHUB REPOSITORY LINK -->
       <a
         href="https://www.github.com/fuda-cafe/hanafuda-art"
         title="View project on GitHub"
         target="_blank"
       >
         <svg
-          class="w-5 h-5 mx-auto mb-2"
+          class="w-5 h-5 mx-auto"
           aria-hidden="true"
           fill="white"
           viewBox="0 0 20 20"
@@ -100,11 +104,35 @@ z"
         </svg>
         <span class="sr-only">View project on GitHub</span>
       </a>
+
+      <!-- ARTIST/CONTRIBUTOR LINK -->
+      <NuxtLink
+        external
+        v-if="!!designInfo.url || !!designInfo.contributorUrl"
+        :href="designInfo.url || designInfo.contributorUrl"
+        :title="designInfo.url ? 'View artist\'s portfolio' : 'View contributor\'s portfolio'"
+        target="_blank"
+      >
+        <Icon name="fa:paint-brush" class="w-5 h-5 mx-auto text-white" />
+        <span class="sr-only">View artist's portfolio</span>
+      </NuxtLink>
     </div>
-    <p class="text-xs text-center text-white">
-      &copy; {{ new Date().getFullYear() }} Developed by Andre L. Hammons
-    </p>
+    <div class="grid text-xs text-center text-white">
+      <p v-memo="[designInfo]" v-if="!!designInfo.by" class="text-sm">
+        Designs illustrated by {{ designInfo.by }}
+      </p>
+      <p v-memo="[designInfo]" v-else-if="!!designInfo.contributor">
+        Art contributed by {{ designInfo.contributor }}
+      </p>
+      <p>
+        &copy; {{ new Date().getFullYear() }} Site developed by Andre L. Hammons
+      </p>
+    </div>
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+const { getDesignInfo, useDesign } = useCardDesign();
+const currentDesign = useDesign();
+const designInfo = computed(() => getDesignInfo(currentDesign.value));
+</script>

--- a/components/StartScreenFooter.vue
+++ b/components/StartScreenFooter.vue
@@ -82,7 +82,7 @@ z"
         <span class="sr-only"> View my portfolio </span>
       </a>
       <a
-        href="https://www.github.com/ahamsammich/new-hanafuda"
+        href="https://www.github.com/fuda-cafe/hanafuda-art"
         title="View project on GitHub"
         target="_blank"
       >

--- a/components/StartScreenFooter.vue
+++ b/components/StartScreenFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed bottom-0 w-screen space-y-2 opacity-50">
+  <div class="fixed w-screen space-y-2 opacity-50 bottom-2">
     <div class="flex items-center mx-auto gap-x-4 w-max">
 
       <!-- PORTFOLIO LINK -->
@@ -105,24 +105,38 @@ z"
         <span class="sr-only">View project on GitHub</span>
       </a>
 
-      <!-- ARTIST/CONTRIBUTOR LINK -->
+      <!-- ATTRIBUTION LINKS -->
+      <!-- Link to creator's URL with contributor URL as fallback -->
+      <!-- Example scenario: creator is known, but does not have a site. -->
       <NuxtLink
         external
-        v-if="!!designInfo.url || !!designInfo.contributorUrl"
-        :href="designInfo.url || designInfo.contributorUrl"
-        :title="designInfo.url ? 'View artist\'s portfolio' : 'View contributor\'s portfolio'"
+        v-if="!!design.by"
+        :to="design.url || design.contributorUrl"
+        :title="design.url ? 'View creator\'s portfolio' : 'View contributor\'s website'"
         target="_blank"
       >
         <Icon name="fa:paint-brush" class="w-5 h-5 mx-auto text-white" />
-        <span class="sr-only">View artist's portfolio</span>
+        <span class="sr-only">View creator's or contributor's website</span>
+      </NuxtLink>
+      <!-- Link to contributor's URL with creator's URL as fallback. -->
+      <!-- Example scenario: contributed art is from an unknown artist. -->
+      <NuxtLink
+        external
+        v-else-if="!!design.contributor"
+        :to="design.contributorUrl || design.url"
+        :title="design.url ? 'View contributor\'s website' : 'View creator\'s portfolio'"
+        target="_blank"
+      >
+        <Icon name="fa:paint-brush" class="w-5 h-5 mx-auto text-white" />
+        <span class="sr-only">View creator's or contributor's website</span>
       </NuxtLink>
     </div>
     <div class="grid text-xs text-center text-white">
-      <p v-memo="[designInfo]" v-if="!!designInfo.by" class="text-sm">
-        Designs illustrated by {{ designInfo.by }}
+      <p v-memo="[design]" v-if="!!design.by">
+        Designs created by {{ design.by }}
       </p>
-      <p v-memo="[designInfo]" v-else-if="!!designInfo.contributor">
-        Art contributed by {{ designInfo.contributor }}
+      <p v-memo="[design]" v-else-if="!!design.contributor">
+        Art contributed by {{ design.contributor }}
       </p>
       <p>
         &copy; {{ new Date().getFullYear() }} Site developed by Andre L. Hammons
@@ -132,7 +146,6 @@ z"
 </template>
 
 <script setup lang="ts">
-const { getDesignInfo, useDesign } = useCardDesign();
-const currentDesign = useDesign();
-const designInfo = computed(() => getDesignInfo(currentDesign.value));
+const { getDesignInfo } = useCardDesign();
+const design = computed(() => getDesignInfo());
 </script>

--- a/composables/useCardDesign.ts
+++ b/composables/useCardDesign.ts
@@ -321,6 +321,13 @@ export const useCardDesign = () => {
 		return url;
 	};
 
+	/**
+	 * 
+	 * @param designName (optional) Name of design to get info for. Defaults to current design.
+	 * @returns Info for the current design or the design specified. 
+	 * See link for more: {@link DesignInfo}
+	 * 
+	 */
 	const getDesignInfo = (designName?: CardDesign) => CARD_DESIGNS[designName ?? useDesign().value];
 
 	const fetchCardUrls = async () => {

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -38,7 +38,7 @@
           </div>
 
           <div class="mt-10">
-            <button id="guest-login-buttonu" type="button" @click="handleLoginAsGuest" class="w-full tracking-wide shadow-md pri-btn">
+            <button id="guest-login-button" type="button" @click="handleLoginAsGuest" class="w-full tracking-wide shadow-md pri-btn">
               Continue as guest
             </button>
 


### PR DESCRIPTION
fix: guest-login-button id

chore: update repo link
- resolves NHP-37

feat: add artist link to start page

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request includes changes to the `StartScreenFooter.vue` and `login.vue` files. The changes include adding a link to the artist's portfolio, updating the GitHub repository link, and fixing a typo in the `login.vue` file.
> 
> ## What changed
> In `StartScreenFooter.vue`, a link to the artist's portfolio was added. The GitHub repository link was updated to point to the correct repository. The footer was also updated to include the name of the artist or contributor and the year of development.
> 
> In `login.vue`, a typo in the id of the guest login button was fixed.
> 
> ## How to test
> To test these changes, follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Navigate to the start screen and check the footer. You should see a link to the artist's portfolio, the updated GitHub repository link, and the updated footer text.
> 3. Click on the artist's portfolio link. It should open the artist's portfolio in a new tab.
> 4. Click on the GitHub repository link. It should open the correct repository in a new tab.
> 5. Navigate to the login page and inspect the guest login button. The id should be `guest-login-button`.
> 
> ## Why make this change
> These changes were made to provide proper credit to the artist or contributor, to ensure that the GitHub repository link points to the correct repository, and to fix a typo in the `login.vue` file. These changes improve the user experience and the accuracy of the information provided on the site.
</details>